### PR TITLE
Fix/filter

### DIFF
--- a/src/lib/AclPermission.ts
+++ b/src/lib/AclPermission.ts
@@ -21,11 +21,15 @@ export class AclPermission {
         this.attributes = params.attributes;
     }
     public filter(data: any): any {
-        return this.attributes
+        const result = this.attributes
             .map(attribute => jp.paths(data, `$..${attribute}`))
             .reduce((a, b) => a.concat(b), [])
             .map((jpPath: string[]) => jpPath.slice(1))
             .map((jpPath: string[]) => [jpPath, path(jpPath, data)])
             .reduce((acc: any, [jpPath, data]: [string[], any]) => assocPath(jpPath, data, acc), {});
+        if (Array.isArray(data)) {
+            return Object.values(result);
+        }
+        return result;
     }
 }

--- a/src/lib/AclPermission.ts
+++ b/src/lib/AclPermission.ts
@@ -1,4 +1,4 @@
-import { assocPath, path } from 'ramda';
+import { assocPath, path, values } from 'ramda';
 const jp = require('jsonpath');
 
 interface AclPermissionParams {
@@ -28,7 +28,7 @@ export class AclPermission {
             .map((jpPath: string[]) => [jpPath, path(jpPath, data)])
             .reduce((acc: any, [jpPath, data]: [string[], any]) => assocPath(jpPath, data, acc), {});
         if (Array.isArray(data)) {
-            return Object.values(result);
+            return values(result);
         }
         return result;
     }

--- a/src/test/acl.test.ts
+++ b/src/test/acl.test.ts
@@ -49,6 +49,75 @@ describe('ACL', () => {
         expect(permission.attributes).toEqual([]);
         expect(allowedBook).toEqual({});
     });
+    test('Basic rule with filter', () => {
+        const ac = new Acl(
+            {
+                user: {
+                    books: {
+                        'read:any': ['chapters.*.name'],
+                    },
+                },
+            },
+            { getRoles: user => user.roles }
+        );
+        const user = { id: 1, roles: ['user'] };
+        const book = {
+            id: 1,
+            ownerId: 1,
+            title: 'The Firm',
+            author: 'John Grisham',
+            chapters: [
+                {
+                    name: 'Mitchell McDeere',
+                    pageStart: 1,
+                    pages: 1,
+                },
+                {
+                    name: 'Bendini, Lambert and Locke',
+                    pageStart: 2,
+                    pages: 2,
+                },
+            ],
+        };
+
+        const permission = ac.can(user).read(book, 'books');
+        const allowedBook = permission.filter(book);
+        expect(allowedBook).toEqual({
+            chapters: [
+                {
+                    name: 'Mitchell McDeere',
+                },
+                {
+                    name: 'Bendini, Lambert and Locke',
+                },
+            ],
+        });
+    });
+    test('Basic rule with array filter', () => {
+        const ac = new Acl(
+            {
+                user: {
+                    books: {
+                        'read:any': ['*'],
+                    },
+                },
+            },
+            { getRoles: user => user.roles }
+        );
+        const user = { id: 1, roles: ['user'] };
+        const books = [
+            {
+                name: 'The Great Gatsby',
+            },
+            {
+                name: 'The Firm',
+            },
+        ];
+
+        const permission = ac.can(user).read(books, 'books');
+        const allowedBook = permission.filter(books);
+        expect(allowedBook).toEqual(books);
+    });
     test('Basic rule - own with owner', () => {
         const ac = new Acl(
             {


### PR DESCRIPTION
This PR fixes arrays filtering. If you send array `[{ test: 1 }, { test: 2 }]` response will be `{ '0': { test: 1 }, '1': { test: 2 } }` - this is not the result we want. So when function received array then it should return array.